### PR TITLE
delete pseudo-elements

### DIFF
--- a/src/styles/_stylesReset.scss
+++ b/src/styles/_stylesReset.scss
@@ -17,11 +17,6 @@
   outline: none;
 }
 
-a:focus,
-a:active {
-  outline: none;
-}
-
 nav,
 footer,
 header,
@@ -48,28 +43,14 @@ select {
   font-family: inherit;
 }
 
-input::-ms-clear {
-  display: none;
-}
-
 button {
   cursor: pointer;
   background-color: transparent;
 }
 
-button::-moz-focus-inner {
-  padding: 0;
-  border: 0;
-}
-
-a,
-a:visited {
+a {
   text-decoration: none;
   color: inherit;
-}
-
-a:hover {
-  text-decoration: none;
 }
 
 ol,


### PR DESCRIPTION
К сожалению, не знал несколько вещей:
1) Некоторые псевдо элементы, по своей специфике, похоже, что имеют больший приоритет, нежели классы, которые мы прописываем. Например:
a:visited { color: inherit } перекрывал мой класс, в котором я менял цвет ссылки
2) Псевдо элементы ::ms-clear и ::-moz-focus-inner нестандартны и не рекомендованы к использованию
https://docs2.w3cub.com/css/::-ms-clear/
https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-focus-inner
Исходя из выше описанного удалил почти все псевдо элементы
Будем добавлять их в случае необходимости в ходе разработки
